### PR TITLE
Makes it possible to flush a batch

### DIFF
--- a/batch/batch-test.js
+++ b/batch/batch-test.js
@@ -103,7 +103,7 @@ test("batch.queue callback called after events fired in the same fn", function()
 });
 
 
-test("afterPreviousEvents doesn't run after all collecting previous events (#17)", function(){
+QUnit.test("afterPreviousEvents doesn't run after all collecting previous events (#17)", function(){
 	var obj = assign({}, canEvent);
 	var afterPreviousEventsFired = false;
 	obj.on("first", function(){
@@ -116,4 +116,42 @@ test("afterPreviousEvents doesn't run after all collecting previous events (#17)
 		afterPreviousEventsFired = true;
 	});
 	canBatch.stop();
+});
+
+
+QUnit.test("flushing works", function(){
+	var firstFired, secondFired, thirdFired;
+	var obj = assign({}, canEvent);
+
+	obj.on("first", function(){
+		canBatch.flush();
+		QUnit.ok(firstFired, "first fired");
+		QUnit.ok(secondFired, "second fired");
+		QUnit.ok(thirdFired, "third fired");
+	});
+	obj.on("first", function(){
+		firstFired = true;
+	});
+	obj.on("second", function(){
+		secondFired = true;
+	});
+	obj.on("third", function(){
+		thirdFired = true;
+	})
+	canBatch.start();
+	obj.dispatch("first");
+	obj.dispatch("second");
+	obj.dispatch("third");
+	canBatch.stop();
+
+});
+
+
+QUnit.test("flush is non enumerable", 1, function(){
+	QUnit.equal( canEvent.flush, canBatch.flush );
+	for(var prop in canEvent) {
+		if(prop === "flush") {
+			ok(false, "flush is enumerable");
+		}
+	}
 });

--- a/batch/batch-test.js
+++ b/batch/batch-test.js
@@ -119,7 +119,7 @@ QUnit.test("afterPreviousEvents doesn't run after all collecting previous events
 });
 
 
-QUnit.test("flushing works", function(){
+QUnit.test("flushing works (#18)", function(){
 	var firstFired, secondFired, thirdFired;
 	var obj = assign({}, canEvent);
 
@@ -137,7 +137,7 @@ QUnit.test("flushing works", function(){
 	});
 	obj.on("third", function(){
 		thirdFired = true;
-	})
+	});
 	canBatch.start();
 	obj.dispatch("first");
 	obj.dispatch("second");
@@ -147,11 +147,43 @@ QUnit.test("flushing works", function(){
 });
 
 
-QUnit.test("flush is non enumerable", 1, function(){
+QUnit.test("flush is non enumerable (#18)", 1, function(){
 	QUnit.equal( canEvent.flush, canBatch.flush );
 	for(var prop in canEvent) {
 		if(prop === "flush") {
 			ok(false, "flush is enumerable");
 		}
 	}
+});
+
+// The problem with the way atm is doing it ...
+// the batch is ended ... but it doesn't pick up the next item in the queue and process it.
+QUnit.test("flushing a future batch (#18)", function(){
+	var firstFired, secondFired, thirdFired;
+	var obj = assign({}, canEvent);
+
+	obj.on("first", function(){
+		canBatch.start();
+		obj.dispatch("second");
+		obj.dispatch("third");
+		canBatch.stop();
+
+		canBatch.flush();
+		QUnit.ok(firstFired, "first fired");
+		QUnit.ok(secondFired, "second fired");
+		QUnit.ok(thirdFired, "third fired");
+	});
+	obj.on("first", function(){
+		firstFired = true;
+	});
+	obj.on("second", function(){
+		secondFired = true;
+	});
+	obj.on("third", function(){
+		thirdFired = true;
+	});
+	canBatch.start();
+	obj.dispatch("first");
+	canBatch.stop();
+
 });

--- a/batch/batch.js
+++ b/batch/batch.js
@@ -149,15 +149,24 @@ var canBatch = {
 		canBatch.transactions++;
 		if(canBatch.transactions === 1) {
 			var queue = {
-				tasks: [],
-				callbacks: [],
+				// the batch number
 				number: batchNum++,
+
+				// where are we in the task queue
 				index: 0,
-				callbacksIndex: 0,
+				tasks: [],
+
+				// the batch end event has fired
 				batchEnded: false,
+
+				// where are we in the post-batch queue
+				callbacksIndex: 0,
+				callbacks: [],
+
+				// if everything this batch can do has been done
 				complete: false
 			};
-			//queues.push(queue);
+
 			if (batchStopHandler) {
 				queue.callbacks.push(batchStopHandler);
 			}
@@ -270,7 +279,7 @@ var canBatch = {
 				index;
 
 			//!steal-remove-start
-			if(debug && queue.index === 0) {
+			if(debug && queue.index === 0 && queue.index < len) {
 				group("batch running "+queue.number);
 			}
 			//!steal-remove-end

--- a/batch/batch.js
+++ b/batch/batch.js
@@ -262,7 +262,7 @@ var canBatch = {
 		}
 	},
 	// Flushes the current
-	flush: function( primaryDepth, depth ) {
+	flush: function() {
 		//!steal-remove-start
 		var debug = canDev.logLevel >= 1;
 		//!steal-remove-end
@@ -305,7 +305,7 @@ var canBatch = {
 				}
 				//!steal-remove-end
 				queue.batchEnded = true;
-				canEvent.dispatchSync.call(canBatch,"batchEnd",[queue.number, primaryDepth, depth]);
+				canEvent.dispatchSync.call(canBatch,"batchEnd",[queue.number]);
 			}
 
 			//!steal-remove-start

--- a/can-event_test.js
+++ b/can-event_test.js
@@ -204,3 +204,12 @@ test('Test events using mixin', function() {
 	other.dispatch('action');
 	equal(bindCount, 2, 'action triggered twice');
 });
+
+
+QUnit.test("makeHandlerArgs and handlers are non enumerable", 0, function(){
+	for(var prop in canEvent) {
+		if(prop === "makeHandlerArgs" || prop === "handlers" ) {
+			ok(false, prop+ " is enumerable");
+		}
+	}
+});

--- a/can-event_test.js
+++ b/can-event_test.js
@@ -160,6 +160,7 @@ test('One will listen to an event once, then unbind', function() {
 	obj.one('mixin', function() {
 		mixin++;
 	});
+	
 	obj.dispatch('mixin');
 	obj.dispatch('mixin');
 	obj.dispatch('mixin');


### PR DESCRIPTION
fixes #18 

- Makes it so a `.flush()` can immediately "complete" any currently running batch and any other batches.
- Adds a debug.
- Adds `flush` to canEvent, makes batch and async overwrite flush w/ their own flush.
- When dispatching events, every event handler is put in the queue at that time ... no late binding.