### PR TITLE
Makes lifecycle a mixin function

### DIFF
--- a/can-event_test.js
+++ b/can-event_test.js
@@ -1,4 +1,5 @@
 var canEvent = require('can-event');
+var lifecycle = require('can-event/lifecycle/lifecycle');
 var QUnit = require('steal-qunit');
 var assign = require('can-util/js/assign/');
 require('can-util/dom/events/delegate/');
@@ -160,7 +161,7 @@ test('One will listen to an event once, then unbind', function() {
 	obj.one('mixin', function() {
 		mixin++;
 	});
-	
+
 	obj.dispatch('mixin');
 	obj.dispatch('mixin');
 	obj.dispatch('mixin');
@@ -213,4 +214,59 @@ QUnit.test("makeHandlerArgs and handlers are non enumerable", 0, function(){
 			ok(false, prop+ " is enumerable");
 		}
 	}
+});
+
+QUnit.module("can-event/lifecycle");
+
+QUnit.test("Mixins your addEventListener", function(){
+	var proto = {
+		addEventListener: function(){
+			QUnit.ok(true, "this was called");
+		},
+		removeEventListener: function(){}
+	};
+
+	var obj = lifecycle(proto);
+	obj.addEventListener("Hello world!");
+});
+
+QUnit.test("Mixins your removeEventListener", function(){
+	var proto = {
+		removeEventListener: function(){
+			QUnit.ok(true, "this was called");
+		},
+		addEventListener: canEvent.addEventListener
+	};
+
+	var obj = lifecycle(proto);
+	obj.addEventListener("some-event");
+	obj.removeEventListener("some-event");
+});
+
+QUnit.test("Calls _eventSetup on the first addEventListener", function(){
+	var proto = {
+		_eventSetup: function(){
+			QUnit.ok(true, "eventSetup was called");
+		},
+		addEventListener: function(){},
+		removeEventListener: function(){}
+	};
+
+	var obj = lifecycle(proto);
+	obj.addEventListener("Something");
+});
+
+QUnit.test("Calls _eventTeardown on the last removeEventListener", function(){
+	var proto = {
+		_eventTeardown: function(){
+			QUnit.ok(true, "eventTeardown was called");
+		},
+		addEventListener: canEvent.addEventListener,
+		removeEventListener: canEvent.removeEventListener
+	};
+
+	var obj = lifecycle(proto);
+	var handler = function(){};
+	obj.addEventListener("Something", handler);
+	obj.removeEventListener("Something", handler);
 });

--- a/can-event_test.js
+++ b/can-event_test.js
@@ -1,10 +1,10 @@
 var canEvent = require('can-event');
-var lifecycle = require('can-event/lifecycle/lifecycle');
 var QUnit = require('steal-qunit');
 var assign = require('can-util/js/assign/');
 require('can-util/dom/events/delegate/');
 require("can-event/batch/batch-test");
 require("can-event/async/async-test");
+require("can-event/lifecycle/lifecycle-test");
 
 QUnit.module('can-event');
 
@@ -214,59 +214,4 @@ QUnit.test("makeHandlerArgs and handlers are non enumerable", 0, function(){
 			ok(false, prop+ " is enumerable");
 		}
 	}
-});
-
-QUnit.module("can-event/lifecycle");
-
-QUnit.test("Mixins your addEventListener", function(){
-	var proto = {
-		addEventListener: function(){
-			QUnit.ok(true, "this was called");
-		},
-		removeEventListener: function(){}
-	};
-
-	var obj = lifecycle(proto);
-	obj.addEventListener("Hello world!");
-});
-
-QUnit.test("Mixins your removeEventListener", function(){
-	var proto = {
-		removeEventListener: function(){
-			QUnit.ok(true, "this was called");
-		},
-		addEventListener: canEvent.addEventListener
-	};
-
-	var obj = lifecycle(proto);
-	obj.addEventListener("some-event");
-	obj.removeEventListener("some-event");
-});
-
-QUnit.test("Calls _eventSetup on the first addEventListener", function(){
-	var proto = {
-		_eventSetup: function(){
-			QUnit.ok(true, "eventSetup was called");
-		},
-		addEventListener: function(){},
-		removeEventListener: function(){}
-	};
-
-	var obj = lifecycle(proto);
-	obj.addEventListener("Something");
-});
-
-QUnit.test("Calls _eventTeardown on the last removeEventListener", function(){
-	var proto = {
-		_eventTeardown: function(){
-			QUnit.ok(true, "eventTeardown was called");
-		},
-		addEventListener: canEvent.addEventListener,
-		removeEventListener: canEvent.removeEventListener
-	};
-
-	var obj = lifecycle(proto);
-	var handler = function(){};
-	obj.addEventListener("Something", handler);
-	obj.removeEventListener("Something", handler);
 });

--- a/lifecycle/lifecycle-test.js
+++ b/lifecycle/lifecycle-test.js
@@ -1,0 +1,58 @@
+var canEvent = require('can-event');
+var lifecycle = require('can-event/lifecycle/lifecycle');
+var QUnit = require('steal-qunit');
+
+QUnit.module("can-event/lifecycle");
+
+QUnit.test("Mixins your addEventListener", function(){
+	var proto = {
+		addEventListener: function(){
+			QUnit.ok(true, "this was called");
+		},
+		removeEventListener: function(){}
+	};
+
+	var obj = lifecycle(proto);
+	obj.addEventListener("Hello world!");
+});
+
+QUnit.test("Mixins your removeEventListener", function(){
+	var proto = {
+		removeEventListener: function(){
+			QUnit.ok(true, "this was called");
+		},
+		addEventListener: canEvent.addEventListener
+	};
+
+	var obj = lifecycle(proto);
+	obj.addEventListener("some-event");
+	obj.removeEventListener("some-event");
+});
+
+QUnit.test("Calls _eventSetup on the first addEventListener", function(){
+	var proto = {
+		_eventSetup: function(){
+			QUnit.ok(true, "eventSetup was called");
+		},
+		addEventListener: function(){},
+		removeEventListener: function(){}
+	};
+
+	var obj = lifecycle(proto);
+	obj.addEventListener("Something");
+});
+
+QUnit.test("Calls _eventTeardown on the last removeEventListener", function(){
+	var proto = {
+		_eventTeardown: function(){
+			QUnit.ok(true, "eventTeardown was called");
+		},
+		addEventListener: canEvent.addEventListener,
+		removeEventListener: canEvent.removeEventListener
+	};
+
+	var obj = lifecycle(proto);
+	var handler = function(){};
+	obj.addEventListener("Something", handler);
+	obj.removeEventListener("Something", handler);
+});

--- a/lifecycle/lifecycle.md
+++ b/lifecycle/lifecycle.md
@@ -1,0 +1,29 @@
+@module {Object} can-event/lifecycle/lifecycle
+@parent can-infrastructure
+
+@description Mixin lifecycle events onto a prototype.
+
+@signature `lifecycle(prototype)`
+
+The `can-event/lifecycle/lifecycle` module adds lifecycle events to a prototype that already has `addEventListener` and `removeEventListener`. It allows you to define:
+
+ - `_eventSetup`: A method that is called the first time a binding is added to the object.
+ - `_eventTeardown`: A method that is called when there are no longer any more bindings on an object.
+
+@body
+
+## Use
+
+To use lifecycle events, provide an object with add/removeEventListener methods.
+
+```js
+var Todo = function(){
+
+};
+
+lifecycle(assign(Todo.prototype, canEvent));
+
+Todo.prototype._eventSetup = function(){
+	// Called the first time bindings are added.
+};
+```


### PR DESCRIPTION
This turns can-event/lifecycle/lifecycle into a mixin function that
wraps existing addEventListener and removeEventListener functions. You
pass it in an object like:

```js
lifecycle({
	addEventListener: function(){},
	addEventListener: function(){}
});
```

And it will wrap these functions to add its own lifecycle stuff, calling
_eventSetup and _eventTeardown.

Closes #30