### PR TITLE
warns if two batches are loaded

### DIFF
--- a/batch/batch.js
+++ b/batch/batch.js
@@ -569,4 +569,8 @@ canBatch.trigger = function(){
 
 canTypes.queueTask = canBatch.queue;
 
-module.exports = namespace.batch = canBatch;
+if (namespace.batch) {
+	throw new Error("You can't have two versions of can-event/batch/batch, check your dependencies");
+} else {
+	module.exports = namespace.batch = canBatch;
+}


### PR DESCRIPTION
Only one version of `can-event/batch/batch` should be loaded at one time.  This makes sure that is the case.  