### PR TITLE
Push _bindings count into __bindEvents object

### DIFF
--- a/lifecycle/lifecycle.js
+++ b/lifecycle/lifecycle.js
@@ -19,14 +19,15 @@ var lifecycle = function(prototype) {
 		// If not initializing, and the first binding
 		// call bindsetup if the function exists.
 		if (!this.__inSetup) {
-			if (!this._bindings) {
-				this._bindings = 1;
+			this.__bindEvents = this.__bindEvents || {};
+			if (!this.__bindEvents._lifecycleBindings) {
+				this.__bindEvents._lifecycleBindings = 1;
 				// setup live-binding
 				if (this._eventSetup) {
 					this._eventSetup();
 				}
 			} else {
-				this._bindings++;
+				this.__bindEvents._lifecycleBindings++;
 			}
 		}
 		return ret;
@@ -42,16 +43,16 @@ var lifecycle = function(prototype) {
 
 		// Remove the event handler
 		var ret = baseRemoveEventListener.apply(this, arguments);
-		if (this._bindings === null) {
-			this._bindings = 0;
+		if (this.__bindEvents._lifecycleBindings === null) {
+			this.__bindEvents._lifecycleBindings = 0;
 		} else {
 			// Subtract the difference in the number of handlers bound to this
 			// event before/after removeEvent
-			this._bindings = this._bindings - (handlerCount - handlers.length);
+			this.__bindEvents._lifecycleBindings -= (handlerCount - handlers.length);
 		}
 		// If there are no longer any bindings and
 		// there is a bindteardown method, call it.
-		if (!this._bindings && this._eventTeardown) {
+		if (!this.__bindEvents._lifecycleBindings && this._eventTeardown) {
 			this._eventTeardown();
 		}
 		return ret;


### PR DESCRIPTION
This property is also now called _lifecycleBindings for clarity.

Why do this?

With DefineMaps and other objects which get defined with can-define, we put a few extra properties to manage data and bindings onto the objects.  Most of these are either objects (`_data`, `__bindEvents`) or fixed primitive values (`_cid`) and can be defined as not writable.  `_bindings` has been an exception to this, as a numeric value that needs to be writable, and this is a problem.  If you `assign()` an object with this property to a defined object (like, for example, a can-map) it will overwrite the lifecycle bindings count and teardown bindings at the wrong time (or not at all).

So rather than putting a lot of gymnastics into incrementing/decrementing bindings in defined objects, this protects the lifecycle binding count by putting it into the non-writable (in can-define) `__bindEvents` object.