### PR TITLE
Update can-util to enable delegated enter/leave events

### DIFF
--- a/can-event.js
+++ b/can-event.js
@@ -16,6 +16,7 @@ var isEmptyObject = require('can-util/js/is-empty-object/is-empty-object');
 var domDispatch = require('can-util/dom/dispatch/dispatch');
 var namespace = require('can-namespace');
 require('can-util/dom/events/delegate/delegate');
+require('can-util/dom/events/delegate/enter-leave');
 
 function makeHandlerArgs(event, args) {
     if (typeof event === 'string') {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "can-cid": "^1.0.0",
     "can-namespace": "1.0.0",
     "can-types": "^1.0.1",
-    "can-util": "^3.1.1"
+    "can-util": "^3.6.0"
   },
   "devDependencies": {
     "bit-docs": "0.0.7",


### PR DESCRIPTION
Adding delegate/enter-leave which enables delegated (mouse|pointer)(enter|leave) events.