### PR TITLE
removing dev warning test in production

### DIFF
--- a/can-event_test.js
+++ b/can-event_test.js
@@ -217,6 +217,7 @@ QUnit.test("makeHandlerArgs and handlers are non enumerable", 0, function(){
 	}
 });
 
+//!steal-remove-start
 QUnit.test("makeHandlerArgs warns on impropper args", function() {
 	var obj = {
 		addEvent: canEvent.addEvent,
@@ -254,3 +255,4 @@ QUnit.test("makeHandlerArgs warns on impropper args", function() {
 
 	canDev.warn = oldWarn;
 });
+//!steal-remove-end


### PR DESCRIPTION
closes https://github.com/canjs/can-event/issues/52.