### PR TITLE
fix issue with debounce removing all batchEnd events

### DIFF
--- a/batch/batch.js
+++ b/batch/batch.js
@@ -589,7 +589,7 @@ Object.defineProperty(canBatch, 'debounce', {
 		return function() {
 			if (!that) {
 				canEvent.addEventListener.call(canBatch, "batchEnd", function listener() {
-					canEvent.removeEventListener.call(canBatch, "batchEnd");
+					canEvent.removeEventListener.call(canBatch, "batchEnd", listener);
 
 					handler.apply(that, args);
 					that = null;


### PR DESCRIPTION
this was causing issues with other tests in the full CanJS test suite