### PR TITLE
Moved debug var to top and check if console is present

### DIFF
--- a/batch/batch.js
+++ b/batch/batch.js
@@ -17,7 +17,7 @@ var canLog = require("can-util/js/log/log");
 
 //!steal-remove-start
 var consoleDefined = typeof console !== 'undefined';
-var group = consoleDefined && console.group && console.group.bind(console) || canLog.log;
+var group = consoleDefined && console.group && console.group.bind(console) || function() {};
 var groupEnd = consoleDefined && console.groupEnd && console.groupEnd.bind(console) || function() {};
 //!steal-remove-end
 

--- a/batch/batch.js
+++ b/batch/batch.js
@@ -16,8 +16,8 @@ var canDev = require("can-util/js/dev/dev");
 var canLog = require("can-util/js/log/log");
 
 //!steal-remove-start
-var debug = canDev.logLevel >= 1;
-if (debug && typeof console !== 'undefined') {
+var consoleDefined = typeof console !== 'undefined';
+if (consoleDefined) {
 	var group = console.group && console.group.bind(console) || canLog.log;
 	var groupEnd = console.groupEnd && console.groupEnd.bind(console) || function() {};
 }
@@ -270,6 +270,9 @@ var canBatch = {
 	},
 	// Flushes the current
 	flush: function() {
+		//!steal-remove-start
+		var debug = canDev.logLevel >= 1;
+		//!steal-remove-end
 
 		dispatchingQueues = true;
 		while(queues.length) {
@@ -282,7 +285,7 @@ var canBatch = {
 			var len = tasks.length;
 
 			//!steal-remove-start
-			if(debug && queue.index === 0 && queue.index < len) {
+			if(consoleDefined && debug && queue.index === 0 && queue.index < len) {
 				group("batch running "+queue.number);
 			}
 			//!steal-remove-end
@@ -328,7 +331,7 @@ var canBatch = {
 				queues.shift();
 
 				//!steal-remove-start
-				if(debug) {
+				if(consoleDefined && debug) {
 					groupEnd();
 				}
 				//!steal-remove-end

--- a/batch/batch.js
+++ b/batch/batch.js
@@ -16,8 +16,11 @@ var canDev = require("can-util/js/dev/dev");
 var canLog = require("can-util/js/log/log");
 
 //!steal-remove-start
-var group = console.group && console.group.bind(console) || canLog.log;
-var groupEnd = console.groupEnd && console.groupEnd.bind(console) || function() {};
+var debug = canDev.logLevel >= 1;
+if (debug && typeof console !== 'undefined') {
+	var group = console.group && console.group.bind(console) || canLog.log;
+	var groupEnd = console.groupEnd && console.groupEnd.bind(console) || function() {};
+}
 //!steal-remove-end
 
 // Which batch of events this is for -- might not want to send multiple
@@ -267,9 +270,6 @@ var canBatch = {
 	},
 	// Flushes the current
 	flush: function() {
-		//!steal-remove-start
-		var debug = canDev.logLevel >= 1;
-		//!steal-remove-end
 
 		dispatchingQueues = true;
 		while(queues.length) {

--- a/batch/batch.js
+++ b/batch/batch.js
@@ -17,10 +17,8 @@ var canLog = require("can-util/js/log/log");
 
 //!steal-remove-start
 var consoleDefined = typeof console !== 'undefined';
-if (consoleDefined) {
-	var group = console.group && console.group.bind(console) || canLog.log;
-	var groupEnd = console.groupEnd && console.groupEnd.bind(console) || function() {};
-}
+var group = consoleDefined && console.group && console.group.bind(console) || canLog.log;
+var groupEnd = consoleDefined && console.groupEnd && console.groupEnd.bind(console) || function() {};
 //!steal-remove-end
 
 // Which batch of events this is for -- might not want to send multiple
@@ -285,7 +283,7 @@ var canBatch = {
 			var len = tasks.length;
 
 			//!steal-remove-start
-			if(consoleDefined && debug && queue.index === 0 && queue.index < len) {
+			if(debug && queue.index === 0 && queue.index < len) {
 				group("batch running "+queue.number);
 			}
 			//!steal-remove-end
@@ -331,7 +329,7 @@ var canBatch = {
 				queues.shift();
 
 				//!steal-remove-start
-				if(consoleDefined && debug) {
+				if(debug) {
 					groupEnd();
 				}
 				//!steal-remove-end


### PR DESCRIPTION
In IE9 `window.console` is not available unless the dev tools are open and will silently break execution anytime it is referenced.

`console.group` was being used here so I put in a check to see both if we are debugging and if it is available before trying to call it.

For https://github.com/canjs/canjs/issues/3482