### PR TITLE
Prevent running missing batch.stop() warning code within a Zone

### DIFF
--- a/batch/batch.js
+++ b/batch/batch.js
@@ -175,11 +175,18 @@ var canBatch = {
 				complete: false
 			};
 			//!steal-remove-start
-			setTimeout(function(){
-				if (queue.complete === false) {
-					canDev.warn("can-even/batch/batch: start called without corresponding stop");
-				}
-			},canBatch.missingStopWarningTimeout);
+			var setupWarning = function(){
+				setTimeout(function(){
+					if (queue.complete === false) {
+						canDev.warn("can-even/batch/batch: start called without corresponding stop");
+					}
+				}, canBatch.missingStopWarningTimeout);
+			};
+			if(typeof CanZone !== "undefined") {
+				CanZone.ignore(setupWarning)();
+			} else {
+				setupWarning();
+			}
 			//!steal-remove-end
 			if (batchStopHandler) {
 				queue.callbacks.push(batchStopHandler);


### PR DESCRIPTION
This prevents the batch.stop() warning code from running within a Zone,
     which causes the Zone to take > 5000 to complete, which exceeds the
     default timeouts in done-ssr.

Closes #67